### PR TITLE
Specify TargetRubyVersion

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.3
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 Lint/AssignmentInCondition:


### PR DESCRIPTION
In RuboCop's default, TargetRubyVersion is 2.0.
But we almost use the higher version.
If TargetRubyVersion is older than used ruby version, RuboCop says
`unexpected token ...` It's a false positive detection. So, I've specify
the newest ruby version.

Problem
-------

In the setting, RuboCop may detects false negative when use older ruby
version than TargetRubyVersion. But I think it is not important.