### PR TITLE
Add support rubocop 0.46.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 2.3
 
+Bundler/OrderedGems:
+  Enabled: false
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 Lint/AssignmentInCondition:
@@ -165,6 +168,8 @@ Style/EmptyLinesAroundMethodBody:
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
 Style/EmptyLiteral:
+  Enabled: false
+Style/EmptyMethod:
   Enabled: false
 Style/Encoding:
   Enabled: false


### PR DESCRIPTION
See https://github.com/bbatsov/rubocop/releases/tag/v0.46.0