### PR TITLE
RuboCop 0.47.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -73,6 +73,8 @@ Performance/RedundantBlockCall:
 
 Rails/Delegate:
   Enabled: false
+Rails/FilePath:
+  Enabled: false
 Rails/HttpPositionalArguments:
   Enabled: false
 Rails/Output:
@@ -80,6 +82,8 @@ Rails/Output:
 Rails/OutputSafety:
   Enabled: false
 Rails/PluralizationGrammar:
+  Enabled: false
+Rails/SkipsModelValidations:
   Enabled: false
 Rails/ReadWriteAttribute:
   Enabled: false

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -21,8 +21,6 @@ Lint/EmptyWhen:
   Enabled: false
 Lint/EndAlignment:
   Enabled: false
-Lint/Eval:
-  Enabled: false
 Lint/HandleExceptions:
   Enabled: false
 Lint/Loop:
@@ -88,6 +86,9 @@ Rails/ReadWriteAttribute:
 Rails/RequestReferer:
   Enabled: false
 Rails/SafeNavigation:
+  Enabled: false
+
+Security/Eval:
   Enabled: false
 
 Style/AccessModifierIndentation:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -90,6 +90,10 @@ Rails/SafeNavigation:
 
 Security/Eval:
   Enabled: false
+Security/MarshalLoad:
+  Enabled: false
+Security/YAMLLoad:
+  Enabled: false
 
 Style/AccessModifierIndentation:
   Enabled: false
@@ -228,6 +232,8 @@ Style/LambdaCall:
 Style/LeadingCommentSpace:
   Enabled: false
 Style/LineEndConcatenation:
+  Enabled: false
+Style/MethodCallWithArgsParentheses:
   Enabled: false
 Style/MethodCallWithoutArgsParentheses:
   Enabled: false

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -229,7 +229,7 @@ Style/LeadingCommentSpace:
   Enabled: false
 Style/LineEndConcatenation:
   Enabled: false
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 Style/MethodDefParentheses:
   Enabled: false


### PR DESCRIPTION
I've checked https://github.com/bbatsov/rubocop/commit/49c32a803e1610df7b6e196e5e9b62d56e6ce7c3

## Added cops

- [x] `Lint/MultipleCompare` https://github.com/bbatsov/rubocop/pull/3795
- [x] `Lint/SafeNavigationChain` https://github.com/bbatsov/rubocop/pull/3804
- [x] `Security/MarshalLoad` https://github.com/bbatsov/rubocop/pull/3816
- [x] `Security/YAMLLoad` https://github.com/bbatsov/rubocop/pull/3821
- [x] `Perfomance/RegexpMatch` https://github.com/bbatsov/rubocop/pull/3824
- [x] `Rails/FilePath` https://github.com/bbatsov/rubocop/pull/3822
- [x] `Rails/SkipsModelValidations` https://github.com/bbatsov/rubocop/pull/3825
- [x] `Rails/ReversibleMigration` https://github.com/bbatsov/rubocop/pull/3854
- [x] `Style/MethodCallWithArgsParentheses` https://github.com/bbatsov/rubocop/pull/3797


## Breaking Changes

- [x] Rename `Lint/Eval` to `Security/Eval`
- [x] `Style/MethodCallWithoutArgsParentheses` https://github.com/bbatsov/rubocop/pull/3797
