### PR TITLE
Display cop name and style guide URL by default

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
     - 'vendor/**/*'
     # db/schema.rb is generated automatically.
     - 'db/schema.rb'
+  DisplayCopName: true
+  DisplayStyleGuide: true
+
 Bundler/OrderedGems:
   Enabled: false
 


### PR DESCRIPTION
By the change, user can receive more information about warnings.

In many cops, there is not much information contained in the message.
But more details exist in the style guide. 
And cop name is useful for google-ability.
