### PR TITLE
Split Style/MethodMissing to follow RuboCop 0.56.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -354,7 +354,9 @@ Style/MethodCallWithoutArgsParentheses:
   Enabled: false
 Style/MethodDefParentheses:
   Enabled: false
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: false
+Style/MethodRespondToMissing:
   Enabled: false
 Style/MixinGrouping:
   Enabled: false

--- a/meowcop.gemspec
+++ b/meowcop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '>= 0.52.0'
+  spec.add_dependency 'rubocop', '>= 0.56.0'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
RuboCop 0.56.0 made `Style/MethodMissing` cop split into two cops. I'd like to follow the change.
See: https://github.com/bbatsov/rubocop/pull/5811