### PR TITLE
Fix unrecognized cops warnings

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -320,8 +320,6 @@ Style/EndBlock:
   Enabled: false
 Style/EvenOdd:
   Enabled: false
-Style/ExtendSelf:
-  Enabled: false
 Style/For:
   Enabled: false
 Style/FormatString:
@@ -356,7 +354,7 @@ Style/MethodDefParentheses:
   Enabled: false
 Style/MethodMissingSuper:
   Enabled: false
-Style/MethodRespondToMissing:
+Style/MissingRespondToMissing:
   Enabled: false
 Style/MixinGrouping:
   Enabled: false


### PR DESCRIPTION
- `Style/ExtendSelf` is removed in v0.52.1 https://github.com/rubocop-hq/rubocop/pull/5233
- `Style/MethodRespondToMissing` is typo. It is `Style/MissingRespondToMissing` https://github.com/sideci/meowcop/pull/26

## Before

```
$ rubocop
Warning: unrecognized cop Style/ExtendSelf found in /home/wata727/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/meowcop-1.16.0/config/rubocop.yml
Warning: unrecognized cop Style/MethodRespondToMissing found in /home/wata727/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/meowcop-1.16.0/config/rubocop.yml
Warning: unrecognized cop Style/ExtendSelf found in .rubocop.yml
Warning: unrecognized cop Style/MethodRespondToMissing found in .rubocop.yml
Inspecting 0 files            


0 files inspected, no offenses detected
```

## After

```
$ rubocop
Inspecting 0 files            


0 files inspected, no offenses detected
```