### PR TITLE
Follow up of new cops (v0.54.0 ~ v0.56.0)

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -90,6 +90,12 @@ Rails/RequestReferer:
   Enabled: false
 Rails/SafeNavigation:
   Enabled: false
+Rails/HttpStatus:
+  Enabled: false
+Rails/RefuteMethods:
+  Enabled: false
+Rails/AssertNot:
+  Enabled: false
 
 Security/Eval:
   Enabled: false
@@ -235,6 +241,10 @@ Layout/BlockAlignment:
 Layout/DefEndAlignment:
   Enabled: false
 Layout/EndAlignment:
+  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+Layout/LeadingBlankLines:
   Enabled: false
 
 Naming/AccessorMethodName:
@@ -487,6 +497,8 @@ Style/WordArray:
 Style/YodaCondition:
   Enabled: false
 Style/ZeroLengthPredicate:
+  Enabled: false
+Style/AccessModifierDeclarations:
   Enabled: false
 
 Gemspec/OrderedDependencies:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -242,10 +242,6 @@ Layout/DefEndAlignment:
   Enabled: false
 Layout/EndAlignment:
   Enabled: false
-Layout/ClosingHeredocIndentation:
-  Enabled: false
-Layout/LeadingBlankLines:
-  Enabled: false
 
 Naming/AccessorMethodName:
   Enabled: false
@@ -497,8 +493,6 @@ Style/WordArray:
 Style/YodaCondition:
   Enabled: false
 Style/ZeroLengthPredicate:
-  Enabled: false
-Style/AccessModifierDeclarations:
   Enabled: false
 
 Gemspec/OrderedDependencies:


### PR DESCRIPTION
## `Style/UnpackFirst`
https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_style.md#styleunpackfirst

**Enabled**

This cop suggests to use `unpack1` instread of `unpack` when pick up first value. `unpack1` is superior to `unpack` in terms of performance. I judged that there was little effect on existing code.

## `Rails/HttpStatus`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_rails.md#railshttpstatus

**Disabled**

This is focus on style.

## `Performance/UnneededSort`

**Enabled**

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_performance.md#performanceunneededsort

## `Lint/SafeNavigationConsistency`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_lint.md#lintsafenavigationconsistency

**Enabled**

## `Performance/InefficientHashSearch`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_performance.md#performanceinefficienthashsearch

**Enabled**

## `Rails/RefuteMethods`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_rails.md#railsrefutemethods

**Disabled**

This cop is focus on style.

## `Rails/AssertNot`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_rails.md#railsassertnot

**Disabled**

This cop is focus on style.

## `Lint/ErbNewArguments`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_lint.md#linterbnewarguments

**Enabled**

## `Style/AccessModifierDeclarations`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_style.md#styleaccessmodifierdeclarations

**Disabled**

This cop focus on style.

## `Style/UnneededCondition`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_style.md#styleunneededcondition

**Enabled**

This cop checks unnecessary conditions. Maybe It's useful.

## `Layout/ClosingHeredocIndentation`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_layout.md#layoutclosingheredocindentation

**Disabled**

This cop focus on style.

## `Layout/LeadingBlankLines`

https://github.com/rubocop-hq/rubocop/blob/v0.57.2/manual/cops_layout.md#layoutleadingblanklines

**Disbaled**

This cop focus on style.

----

BTW, `Layout/ClosingHeredocIndentation`, `Layout/LeadingBlankLines` and `Style/AccessModifierDeclarations` cops are introduced in v0.57.0. For that reason, if use this configuration with RuboCop v0.56.0, it outputs warning messages like the following:

```
$ rubocop _0.56.0_
Warning: unrecognized cop Layout/ClosingHeredocIndentation found in /home/wata727/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/meowcop-1.16.0/config/rubocop.yml
Warning: unrecognized cop Layout/LeadingBlankLines found in /home/wata727/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/meowcop-1.16.0/config/rubocop.yml
Warning: unrecognized cop Style/AccessModifierDeclarations found in /home/wata727/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/meowcop-1.16.0/config/rubocop.yml
Warning: unrecognized cop Layout/ClosingHeredocIndentation found in .rubocop.yml
Warning: unrecognized cop Layout/LeadingBlankLines found in .rubocop.yml
Warning: unrecognized cop Style/AccessModifierDeclarations found in .rubocop.yml
Inspecting 0 files


0 files inspected, no offenses detected
```

In order to avoid these warnings, should I release gem after set RuboCop requirement greater than 0.57.0? please tell me your opinion.